### PR TITLE
[PPV-16] 목록 조회 시 기능 추가

### DIFF
--- a/src/main/java/com/numble/popularpuppyvote/common/mapper/PuppyMapper.java
+++ b/src/main/java/com/numble/popularpuppyvote/common/mapper/PuppyMapper.java
@@ -16,6 +16,8 @@ public class PuppyMapper {
 				.name(request.name())
 				.imageUrl(request.imageUrl())
 				.description(request.description())
+				.species(request.species())
+				.size(request.size())
 				.build();
 	}
 
@@ -30,6 +32,8 @@ public class PuppyMapper {
 				puppy.getName(),
 				puppy.getImageUrl(),
 				puppy.getDescription(),
+				puppy.getSpecies(),
+				puppy.getSize(),
 				puppy.getLikeCount()
 		);
 	}

--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -58,6 +58,14 @@ public class PuppyController {
 		return ResponseEntity.ok(puppyReadService.getPuppies(request));
 	}
 
+	@GetMapping("/filtered")
+	@ResponseStatus(code = HttpStatus.OK)
+	public ResponseEntity<PuppyListGetResponse> getFilteredPuppies(
+			@Valid PuppyListGetRequest request
+	) {
+		return ResponseEntity.ok(puppyReadService.getFilteredPuppies(request));
+	}
+
 	@PatchMapping
 	@ResponseStatus(code = HttpStatus.OK)
 	public ResponseEntity<PuppyUpdateResponse> updatePuppy(

--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.numble.popularpuppyvote.domain.dto.request.PuppyCreateRequest;
+import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
+import com.numble.popularpuppyvote.domain.dto.request.PuppySortedListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyUpdateRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyCreateResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
@@ -58,12 +60,20 @@ public class PuppyController {
 		return ResponseEntity.ok(puppyReadService.getPuppies(request));
 	}
 
-	@GetMapping("/filtered")
+	@GetMapping("/filter")
 	@ResponseStatus(code = HttpStatus.OK)
 	public ResponseEntity<PuppyListGetResponse> getFilteredPuppies(
-			@Valid PuppyListGetRequest request
+			@Valid PuppyFilteredListGetRequest request
 	) {
 		return ResponseEntity.ok(puppyReadService.getFilteredPuppies(request));
+	}
+
+	@GetMapping("/sort")
+	@ResponseStatus(code = HttpStatus.OK)
+	public ResponseEntity<PuppyListGetResponse> getSortedPuppies(
+			@Valid PuppySortedListGetRequest request
+	) {
+		return ResponseEntity.ok(puppyReadService.getSortedPuppies(request));
 	}
 
 	@PatchMapping

--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyCreateRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
@@ -74,6 +75,14 @@ public class PuppyController {
 			@Valid PuppySortedListGetRequest request
 	) {
 		return ResponseEntity.ok(puppyReadService.getSortedPuppies(request));
+	}
+
+	@GetMapping("/enhanced")
+	@ResponseStatus(code = HttpStatus.OK)
+	public ResponseEntity<PuppyListGetResponse> enhancedGetPuppies(
+			@Valid EnhancedPuppyListGetRequest request
+	) {
+		return ResponseEntity.ok(puppyReadService.enhancedGetPuppies(request));
 	}
 
 	@PatchMapping

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/EnhancedPuppyListGetRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/EnhancedPuppyListGetRequest.java
@@ -1,0 +1,17 @@
+package com.numble.popularpuppyvote.domain.dto.request;
+
+import java.util.List;
+
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.SortingCriteria;
+import com.numble.popularpuppyvote.domain.model.Species;
+
+public record EnhancedPuppyListGetRequest(
+		Long cursorId,
+		int pageSize,
+		List<Species> species,
+		List<Size> sizes,
+		SortingCriteria criteria,
+		Boolean isAscending
+) {
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyCreateRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyCreateRequest.java
@@ -1,9 +1,14 @@
 package com.numble.popularpuppyvote.domain.dto.request;
 
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
+
 public record PuppyCreateRequest (
 		String name,
 		String imageUrl,
-		String description
+		String description,
+		Species species,
+		Size size
 ) {
 
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyFilteredListGetRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyFilteredListGetRequest.java
@@ -1,0 +1,14 @@
+package com.numble.popularpuppyvote.domain.dto.request;
+
+import java.util.List;
+
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
+
+public record PuppyFilteredListGetRequest(
+		Long cursorId,
+		int pageSize,
+		List<Species> species,
+		List<Size> sizes
+) {
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyListGetRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyListGetRequest.java
@@ -1,7 +1,14 @@
 package com.numble.popularpuppyvote.domain.dto.request;
 
+import java.util.List;
+
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
+
 public record PuppyListGetRequest(
 		Long cursorId,
-		int pageSize
+		int pageSize,
+		List<Species> species,
+		List<Size> sizes
 ) {
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppySortedListGetRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppySortedListGetRequest.java
@@ -1,0 +1,11 @@
+package com.numble.popularpuppyvote.domain.dto.request;
+
+import com.numble.popularpuppyvote.domain.model.SortingCriteria;
+
+public record PuppySortedListGetRequest(
+		Long cursorId,
+		int pageSize,
+		SortingCriteria criteria,
+		Boolean isAscending
+) {
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/response/PuppyGetResponse.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/response/PuppyGetResponse.java
@@ -1,10 +1,15 @@
 package com.numble.popularpuppyvote.domain.dto.response;
 
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
+
 public record PuppyGetResponse(
 		Long id,
 		String name,
 		String imageUrl,
 		String description,
+		Species species,
+		Size size,
 		int likeCount
 ) {
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/facade/CountingUseCase.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/facade/CountingUseCase.java
@@ -17,8 +17,8 @@ public class CountingUseCase {
 	private final LikesRepository likesRepository;
 	private final PuppyRepository puppyRepository;
 
-	private final int fixedDelay = 60 * 1000;			// 스케쥴링 간격
-	private final int initialDelay = 60 * 1000;		// 어플리케이션 구동 후 스케쥴링 시작 시간
+	private final int fixedDelay = 10 * 60 * 1000;			// 스케쥴링 간격
+	private final int initialDelay = 5 * 60 * 1000;		// 어플리케이션 구동 후 스케쥴링 시작 시간
 
 	@Transactional
 	@Scheduled(fixedDelay = fixedDelay, initialDelay = initialDelay)

--- a/src/main/java/com/numble/popularpuppyvote/domain/facade/CountingUseCase.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/facade/CountingUseCase.java
@@ -5,30 +5,38 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StopWatch;
 
 import com.numble.popularpuppyvote.domain.repository.LikesRepository;
 import com.numble.popularpuppyvote.domain.repository.PuppyRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CountingUseCase {
 	private final LikesRepository likesRepository;
 	private final PuppyRepository puppyRepository;
 
-	private final int fixedDelay = 10 * 60 * 1000;			// 스케쥴링 간격
-	private final int initialDelay = 5 * 60 * 1000;		// 어플리케이션 구동 후 스케쥴링 시작 시간
+	private final int fixedDelay = 5 * 60 * 1000;			// 스케쥴링 간격
+	private final int initialDelay = 10 * 60 * 1000;		// 어플리케이션 구동 후 스케쥴링 시작 시간
 
 	@Transactional
 	@Scheduled(fixedDelay = fixedDelay, initialDelay = initialDelay)
 	public void countLikes(){
 		// TODO 집계 로직 최적화하기
+
+		var schedulingWatch = new StopWatch();
+		schedulingWatch.stop();
 		List<Long> ids = puppyRepository.getAllIdsDistinctGroupBy();
 
 		for (Long id: ids){
 			Integer cnt = likesRepository.getLikesCountByPuppyId(id);
 			puppyRepository.updateLikeCountById(id, cnt);
 		}
+		schedulingWatch.stop();
+		log.info("집계 로직 수행 시간 : " + schedulingWatch.getTotalTimeSeconds() + "s");
  	}
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/model/Puppy.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/model/Puppy.java
@@ -3,6 +3,8 @@ package com.numble.popularpuppyvote.domain.model;
 import static lombok.AccessLevel.PROTECTED;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -29,14 +31,22 @@ public class Puppy extends BaseTimeEntity {
 
 	private String description;
 
+	@Enumerated(EnumType.STRING)
+	private Species species;
+
+	@Enumerated(EnumType.STRING)
+	private Size size;
+
 	private Integer likeCount;
 
 	@Builder
-	public Puppy(Long id, String name, String imageUrl, String description) {
+	public Puppy(Long id, String name, String imageUrl, String description, Species species, Size size) {
 		this.id = id;
 		this.name = name;
 		this.imageUrl = imageUrl;
 		this.description = description;
+		this.size = size;
+		this.species = species;
 		this.likeCount = 0;
 	}
 

--- a/src/main/java/com/numble/popularpuppyvote/domain/model/Size.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/model/Size.java
@@ -1,0 +1,13 @@
+package com.numble.popularpuppyvote.domain.model;
+
+public enum Size {
+	LARGE("대형"),
+	MEDIUM("중형"),
+	SMALL("소형");
+
+	private final String name;
+
+	Size(String name){
+		this.name = name;
+	}
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/model/SortingCriteria.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/model/SortingCriteria.java
@@ -1,0 +1,5 @@
+package com.numble.popularpuppyvote.domain.model;
+
+public enum SortingCriteria {
+	DEFAULT, LIKES, SPECIES,
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/model/Species.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/model/Species.java
@@ -1,0 +1,33 @@
+package com.numble.popularpuppyvote.domain.model;
+
+public enum Species {
+	WELSH_CORGI("웰시코기"),
+	MALTESE("말티즈"),
+	SHIH_TZU("시츄"),
+	DASHSHUND("닥스훈트"),
+	BORDER_COLLIE("보더콜리"),
+	GOLDEN_RETRIEVER("골든리트리버"),
+	PUG("퍼그"),
+	SAMOYED("사모예드"),
+	DALMATIAN("달마시안"),
+	BICHON_FRISE("비숑프리제"),
+	POMERANIAN("포메라니안"),
+	POODLE("푸들"),
+	JINDO_DOG("진돗개"),
+	SHIBA_INU("시바"),
+	BIGGLE("비글"),
+	GERMAN_SHEPHERD("저먼셰퍼드"),
+	CHIHUAHUA("치와와"),
+	BULLDOG("불독"),
+	SIBERIAN_HUSKEY("허스키"),
+	DOBERMAN("도베르만"),
+	YORKSHIRE_TERRIER("요크셔테리어"),
+	GREAT_DANE("그레이트데인"),
+	CHOW_CHOW("차우차우"),
+	ITALIAN_GREYHOUND("이탈리안그레이하운드"),
+	MIXED("믹스");
+
+	private final String name;
+
+	Species(String name) {this.name = name;}
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
@@ -3,8 +3,12 @@ package com.numble.popularpuppyvote.domain.repository;
 import java.util.List;
 
 import com.numble.popularpuppyvote.domain.model.Puppy;
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
 
 public interface PuppyCustomRepository {
 
 	List<Puppy> findPuppies(Long cursorId, int pageSize);
+
+	List<Puppy> findPuppiesWithFiltering(Long cursorId, int pageSize, List<Species> species, List<Size> sizes);
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
@@ -15,4 +15,6 @@ public interface PuppyCustomRepository {
 	List<Puppy> findPuppiesWithFiltering(Long cursorId, int pageSize, List<Species> species, List<Size> sizes);
 
 	List<Puppy> findPuppiesWithSorting(Long compareId, int pageSize, SortingCriteria criteria, Boolean isAscending);
+
+	List<Puppy> findPuppies(Long cursorId, int pageSize, List<Species> species, List<Size> sizes, SortingCriteria criteria, Boolean isAscending);
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
@@ -4,11 +4,15 @@ import java.util.List;
 
 import com.numble.popularpuppyvote.domain.model.Puppy;
 import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.SortingCriteria;
 import com.numble.popularpuppyvote.domain.model.Species;
 
 public interface PuppyCustomRepository {
 
 	List<Puppy> findPuppies(Long cursorId, int pageSize);
 
+	// TODO 포함이 아니라 제외하는 필터링도 구현
 	List<Puppy> findPuppiesWithFiltering(Long cursorId, int pageSize, List<Species> species, List<Size> sizes);
+
+	List<Puppy> findPuppiesWithSorting(Long cursorId, int pageSize, SortingCriteria criteria, Boolean isAscending);
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
@@ -14,5 +14,5 @@ public interface PuppyCustomRepository {
 	// TODO 포함이 아니라 제외하는 필터링도 구현
 	List<Puppy> findPuppiesWithFiltering(Long cursorId, int pageSize, List<Species> species, List<Size> sizes);
 
-	List<Puppy> findPuppiesWithSorting(Long cursorId, int pageSize, SortingCriteria criteria, Boolean isAscending);
+	List<Puppy> findPuppiesWithSorting(Long compareId, int pageSize, SortingCriteria criteria, Boolean isAscending);
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 
 import com.numble.popularpuppyvote.domain.model.Puppy;
 import com.numble.popularpuppyvote.domain.model.QPuppy;
+import com.numble.popularpuppyvote.domain.model.Size;
+import com.numble.popularpuppyvote.domain.model.Species;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -30,7 +32,29 @@ public class PuppyCustomRepositoryImpl implements PuppyCustomRepository {
 				.fetch();
 	}
 
+	@Override
+	public List<Puppy> findPuppiesWithFiltering(Long cursorId, int pageSize, List<Species> species, List<Size> sizes) {
+		return jpaQueryFactory
+				.selectFrom(qPuppy)
+				.where(
+						gtPuppyId(cursorId),
+						inSpecies(qPuppy, species),
+						inSize(qPuppy, sizes)
+				)
+				.orderBy(qPuppy.id.asc())
+				.limit(pageSize)
+				.fetch();
+	}
+
 	private BooleanExpression gtPuppyId(Long cursorId) {
 		return (cursorId != null) ? qPuppy.id.gt(cursorId) : null;
+	}
+
+	private BooleanExpression inSpecies(QPuppy qPuppy, List<Species> species){
+		return species.size() > 0 ? qPuppy.species.in(species) : null;
+	}
+
+	private BooleanExpression inSize(QPuppy qPuppy, List<Size> sizes) {
+		return sizes.size() > 0 ? qPuppy.size.in(sizes) : null;
 	}
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
@@ -65,6 +65,24 @@ public class PuppyCustomRepositoryImpl implements PuppyCustomRepository {
 				.fetch();
 	}
 
+	@Override
+	public List<Puppy> findPuppies(Long cursorId, int pageSize,
+			List<Species> species, List<Size> sizes,
+			SortingCriteria criteria, Boolean isAscending) {
+		return jpaQueryFactory
+				.selectFrom(qPuppy)
+				.where(
+						compare(criteria, cursorId, isAscending),
+						inSpecies(species),
+						inSize(sizes)
+				)
+				.orderBy(
+						criteria(criteria, isAscending)
+				)
+				.limit(pageSize)
+				.fetch();
+	}
+
 	private BooleanExpression gtPuppyId(Long cursorId) {
 		return (cursorId != null) ? qPuppy.id.gt(cursorId) : null;
 	}
@@ -109,6 +127,7 @@ public class PuppyCustomRepositoryImpl implements PuppyCustomRepository {
 		return isAscending ? qPuppy.species.gt(species) : qPuppy.species.lt(species);
 	}
 
+	// TODO 현재는 비교 할 때 쿼리를 하나 더 날리는데, Species, Size에 숫자로 대체해서 lastId를 id가 아닌 id, 좋아요수, enum에서의 위치 등을 저장하는 방식으로 변경(숫자로 통일해서 문제 해결)
 	private BooleanExpression compare(SortingCriteria criteria, Long cursorId, Boolean isAscending) {
 		return cursorId != null ? switch (criteria) {
 			case DEFAULT -> compareByPuppyId(cursorId, isAscending);

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -13,6 +13,7 @@ import javax.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Service;
 
+import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppySortedListGetRequest;
@@ -55,6 +56,17 @@ public class PuppyReadService {
 	@Transactional(readOnly = true)
 	public PuppyListGetResponse getSortedPuppies(PuppySortedListGetRequest request) {
 		List<Puppy> puppies = puppyRepository.findPuppiesWithSorting(request.cursorId(), request.pageSize(),
+				request.criteria(), request.isAscending());
+		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
+
+		return toPuppiesGetResponse(puppies, lastId);
+	}
+
+	@Transactional(readOnly = true)
+	public PuppyListGetResponse enhancedGetPuppies(EnhancedPuppyListGetRequest request) {
+		List<Puppy> puppies = puppyRepository.findPuppies(
+				request.cursorId(), request.pageSize(),
+				request.species(), request.sizes(),
 				request.criteria(), request.isAscending());
 		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
 

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -13,7 +13,9 @@ import javax.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Service;
 
+import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
+import com.numble.popularpuppyvote.domain.dto.request.PuppySortedListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyListGetResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
 import com.numble.popularpuppyvote.domain.model.Puppy;
@@ -28,13 +30,12 @@ public class PuppyReadService {
 	private final PuppyRepository puppyRepository;
 
 	@Transactional(readOnly = true)
-	public PuppyGetResponse getOnePuppy(Long puppyId){
+	public PuppyGetResponse getOnePuppy(Long puppyId) {
 		return toPuppyGetResponse(getEntity(puppyId));
 	}
 
-
 	@Transactional(readOnly = true)
-	public PuppyListGetResponse getPuppies(PuppyListGetRequest request){
+	public PuppyListGetResponse getPuppies(PuppyListGetRequest request) {
 
 		List<Puppy> puppies = puppyRepository.findPuppies(request.cursorId(), request.pageSize());
 		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
@@ -43,8 +44,18 @@ public class PuppyReadService {
 	}
 
 	@Transactional(readOnly = true)
-	public PuppyListGetResponse getFilteredPuppies(PuppyListGetRequest request){
-		List<Puppy> puppies = puppyRepository.findPuppiesWithFiltering(request.cursorId(), request.pageSize(), request.species(), request.sizes());
+	public PuppyListGetResponse getFilteredPuppies(PuppyFilteredListGetRequest request) {
+		List<Puppy> puppies = puppyRepository.findPuppiesWithFiltering(request.cursorId(), request.pageSize(),
+				request.species(), request.sizes());
+		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
+
+		return toPuppiesGetResponse(puppies, lastId);
+	}
+
+	@Transactional(readOnly = true)
+	public PuppyListGetResponse getSortedPuppies(PuppySortedListGetRequest request) {
+		List<Puppy> puppies = puppyRepository.findPuppiesWithSorting(request.cursorId(), request.pageSize(),
+				request.criteria(), request.isAscending());
 		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
 
 		return toPuppiesGetResponse(puppies, lastId);

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -42,6 +42,14 @@ public class PuppyReadService {
 		return toPuppiesGetResponse(puppies, lastId);
 	}
 
+	@Transactional(readOnly = true)
+	public PuppyListGetResponse getFilteredPuppies(PuppyListGetRequest request){
+		List<Puppy> puppies = puppyRepository.findPuppiesWithFiltering(request.cursorId(), request.pageSize(), request.species(), request.sizes());
+		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
+
+		return toPuppiesGetResponse(puppies, lastId);
+	}
+
 	private Puppy getEntity(Long id) {
 		return puppyRepository.findById(id)
 				.orElseThrow(() -> new EntityNotFoundException(String.format(ENTITY_NOT_FOUND.name(), PUPPY.name())));

--- a/src/test/java/com/numble/popularpuppyvote/domain/likes/BulkLike.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/likes/BulkLike.java
@@ -6,12 +6,15 @@ import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.StopWatch;
 
 import com.numble.popularpuppyvote.domain.repository.LikesJdbcRepository;
 import com.numble.popularpuppyvote.domain.repository.LikesRepository;
 import com.numble.popularpuppyvote.domain.utils.LikesFixtureFactory;
 
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @SpringBootTest
 public class BulkLike {
 
@@ -25,20 +28,48 @@ public class BulkLike {
 	void testTest() {
 		LongStream.range(0, 10)
 				.mapToObj(i -> LikesFixtureFactory.create(i, 7L))
-				.forEach(likes -> {
-					System.out.println("ID : " + likes.getId() + ", puppy id : " + likes.getPuppyId() + ", isDeleted : " + likes.getIsDeleted());
-				});
+				.forEach(likes -> System.out.println(
+								"ID : " + likes.getId() + ", puppy id : " + likes.getPuppyId() + ", isDeleted : " + likes.getIsDeleted()
+						)
+				);
 	}
 
 	@Test
 	void insertLikesBulk() {
 
-		var likes = IntStream.range(0, 10 * 10000)
-				.parallel()
-				.mapToObj(i -> LikesFixtureFactory.create(i ,20L))
-				.toList();
+		int dateSize = 10 * 10000;
+		StopWatch generatingData, bulkInsert;
 
-		likesJdbcRepository.bulkInsert(likes);
-		// likesRepository.saveAll(likes);
+		for (int i = 1; i < 11; i++) {
+			generatingData = new StopWatch();
+			bulkInsert = new StopWatch();
+
+			generatingData.start();
+			var likes = IntStream.range(0, dateSize)
+					.parallel()
+					.mapToObj(o -> LikesFixtureFactory.create(o, 25L))
+					.toList();
+			generatingData.stop();
+
+			bulkInsert.start();
+			likesJdbcRepository.bulkInsert(likes);
+			bulkInsert.stop();
+
+			String logString = String.format("""
+					# %d: 데이터 크기 : %d, 데이터 생성에 걸리는 시간 : %.3fs, 데이터 삽입에 걸리는 시간 : %.3fs
+					""", i, dateSize, generatingData.getTotalTimeSeconds(), bulkInsert.getTotalTimeSeconds()
+			);
+
+			log.info(logString);
+		}
+	}
+
+	@Test
+	void stringTest() {
+		double a = 12.123456;
+		String logString = String.format("""
+				%d, %.4fs
+				""", 1, a);
+		log.info(logString);
 	}
 }

--- a/src/test/java/com/numble/popularpuppyvote/domain/puppy/PuppyTest.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/puppy/PuppyTest.java
@@ -1,6 +1,7 @@
 package com.numble.popularpuppyvote.domain.puppy;
 
 import java.util.List;
+import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.StopWatch;
 
 import com.numble.popularpuppyvote.domain.repository.PuppyRepository;
+import com.numble.popularpuppyvote.domain.utils.PuppyFixtureFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,7 +21,7 @@ public class PuppyTest {
 	PuppyRepository puppyRepository;
 
 	@Test
-	void timeTest(){
+	void timeTest() {
 		var groupByWatch = new StopWatch();
 		var distinctWatch = new StopWatch();
 		var groupByAndDistinctWatch = new StopWatch();
@@ -38,5 +40,15 @@ public class PuppyTest {
 		List<Long> mixedIds = puppyRepository.getAllIdsDistinctGroupBy();
 		groupByAndDistinctWatch.stop();
 		log.info("Mixed Time : " + groupByAndDistinctWatch.getTotalTimeMillis() + "ms");
+	}
+
+	@Test
+	void puppyBulkInsert() {
+		var puppies = LongStream.range(0, 25)
+				.parallel()
+				.mapToObj(PuppyFixtureFactory::create)
+				.toList();
+
+		puppyRepository.saveAll(puppies);
 	}
 }

--- a/src/test/java/com/numble/popularpuppyvote/domain/puppy/PuppyTest.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/puppy/PuppyTest.java
@@ -44,7 +44,7 @@ public class PuppyTest {
 
 	@Test
 	void puppyBulkInsert() {
-		var puppies = LongStream.range(0, 25)
+		var puppies = LongStream.range(0, 25L)
 				.parallel()
 				.mapToObj(PuppyFixtureFactory::create)
 				.toList();

--- a/src/test/java/com/numble/popularpuppyvote/domain/puppy/service/PuppyServiceTest.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/puppy/service/PuppyServiceTest.java
@@ -1,8 +1,9 @@
 package com.numble.popularpuppyvote.domain.puppy.service;
 
+import static com.numble.popularpuppyvote.domain.model.Species.WELSH_CORGI;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyCreateRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyCreateResponse;
 import com.numble.popularpuppyvote.domain.model.Puppy;
+import com.numble.popularpuppyvote.domain.model.Size;
 import com.numble.popularpuppyvote.domain.repository.PuppyRepository;
 import com.numble.popularpuppyvote.domain.service.PuppyService;
 
@@ -33,7 +35,7 @@ public class PuppyServiceTest {
 
 	@BeforeEach
 	void beforeEach() {
-		puppy = new Puppy(1L, "coco", "coco.com", "귀여운 코코");
+		puppy = new Puppy(1L, "coco", "coco.com", "귀여운 코코", WELSH_CORGI, Size.MEDIUM);
 	}
 
 	@Nested
@@ -44,7 +46,7 @@ public class PuppyServiceTest {
 		@DisplayName("강아지를 등록한다")
 		void registerPuppy() {
 			// Given
-			PuppyCreateRequest request = new PuppyCreateRequest("coco", "coco.com", "귀여운 코코");
+			PuppyCreateRequest request = new PuppyCreateRequest("coco", "coco.com", "귀여운 코코", WELSH_CORGI, Size.MEDIUM);
 			given(puppyRepository.save(any(Puppy.class))).willReturn(puppy);
 
 			// When

--- a/src/test/java/com/numble/popularpuppyvote/domain/utils/PuppyFixtureFactory.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/utils/PuppyFixtureFactory.java
@@ -1,0 +1,34 @@
+package com.numble.popularpuppyvote.domain.utils;
+
+import static org.jeasy.random.FieldPredicates.inClass;
+import static org.jeasy.random.FieldPredicates.named;
+import static org.jeasy.random.FieldPredicates.ofType;
+
+import java.time.LocalDate;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+
+import com.numble.popularpuppyvote.domain.model.Puppy;
+
+public class PuppyFixtureFactory {
+
+	public static Puppy create(Long seed) {
+		var idPredicate = named("id")
+				.and(ofType(Long.class))
+				.and(inClass(Puppy.class));
+
+		var likeCountPredicate = named("likeCount")
+				.and(ofType(Integer.class))
+				.and(inClass(Puppy.class));
+
+		var params = new EasyRandomParameters()
+				.seed(seed)
+				.stringLengthRange(2, 10)
+				.dateRange(LocalDate.of(2022, 11, 10), LocalDate.of(2023, 5, 10))
+				.randomize(idPredicate, () -> seed)
+				.randomize(likeCountPredicate, () -> 0);
+
+		return new EasyRandom(params).nextObject(Puppy.class);
+	}
+}


### PR DESCRIPTION
[PPV-17] 보다 더 많은 정보 제공을 위한 Entity 칼럼 추가
- 세부 종 표현을 위한 Species
- 크기 표현을 위한 Size
[PPV-18] 특정 조건을 기준으로 필터링된 결과만 나오도록 조회 메서드 작성
- 특정 종만 검색 가능
- 특정 사이즈만 검색 가능
[PPV-19] 특정 조건을 기준으로 정렬된 결과를 보도록 조회 메소드 작성
- 기본 id 기준(등록 날짜 기준)
- 받은 좋아요 수 기준
- 종이름의 알파벳 순서
- 모든 조건은 오름차순, 내림차순으로 조건 변경 가능
[PPV-20] 조회 메소드 정렬, 필터링 기능 통합


기타 : Puppy 도 BulkInsert 되도록 추가