### PR TITLE
[PPV-29] API 를 정리한다

### DIFF
--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -42,15 +42,8 @@ public class PuppyController {
 	) {
 		return new ResponseEntity<>(puppyService.registerPuppy(request), HttpStatus.CREATED);
 	}
-	@GetMapping("/{puppyId}")
-	@ResponseStatus(code = HttpStatus.OK)
-	public ResponseEntity<PuppyGetResponse> getOnePuppy(
-			@PathVariable Long puppyId
-	) {
-		return ResponseEntity.ok(puppyReadService.getOnePuppyWithOutRedis(puppyId));
-	}
 
-	@GetMapping("/redis/{puppyId}")
+	@GetMapping("/{puppyId}")
 	@ResponseStatus(code = HttpStatus.OK)
 	public ResponseEntity<PuppyGetResponse> getOnePuppyWithRedis(
 			@PathVariable Long puppyId// , HttpSession session
@@ -71,7 +64,7 @@ public class PuppyController {
 	public ResponseEntity<PuppyListGetResponse> enhancedGetPuppies(
 			@Valid EnhancedPuppyListGetRequest request
 	) {
-		return ResponseEntity.ok(puppyReadService.enhancedGetPuppies(request));
+		return ResponseEntity.ok(puppyReadService.getPuppiesWithSortingAndFiltering(request));
 	}
 
 	@PatchMapping

--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -45,13 +45,13 @@ public class PuppyController {
 
 	@GetMapping("/{puppyId}")
 	@ResponseStatus(code = HttpStatus.OK)
-	public ResponseEntity<PuppyGetResponse> getOnePuppyWithRedis(
+	public ResponseEntity<PuppyGetResponse> getOnePuppy(
 			@PathVariable Long puppyId// , HttpSession session
 	) {
 		return ResponseEntity.ok(puppyReadService.getOnePuppy(puppyId));
 	}
 
-	@GetMapping
+	@GetMapping("/many")
 	@ResponseStatus(code = HttpStatus.OK)
 	public ResponseEntity<PuppyListGetResponse> getPuppies(
 			@Valid PuppyListGetRequest request
@@ -59,12 +59,12 @@ public class PuppyController {
 		return ResponseEntity.ok(puppyReadService.getPuppies(request));
 	}
 
-	@GetMapping("/enhanced")
+	@GetMapping("/many/condition")
 	@ResponseStatus(code = HttpStatus.OK)
-	public ResponseEntity<PuppyListGetResponse> enhancedGetPuppies(
+	public ResponseEntity<PuppyListGetResponse> getManyPuppiesWithCondition(
 			@Valid EnhancedPuppyListGetRequest request
 	) {
-		return ResponseEntity.ok(puppyReadService.getPuppiesWithSortingAndFiltering(request));
+		return ResponseEntity.ok(puppyReadService.getManyPuppiesWithCondition(request));
 	}
 
 	@PatchMapping

--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -16,9 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyCreateRequest;
-import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
-import com.numble.popularpuppyvote.domain.dto.request.PuppySortedListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyUpdateRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyCreateResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
@@ -44,11 +42,18 @@ public class PuppyController {
 	) {
 		return new ResponseEntity<>(puppyService.registerPuppy(request), HttpStatus.CREATED);
 	}
-
 	@GetMapping("/{puppyId}")
 	@ResponseStatus(code = HttpStatus.OK)
 	public ResponseEntity<PuppyGetResponse> getOnePuppy(
 			@PathVariable Long puppyId
+	) {
+		return ResponseEntity.ok(puppyReadService.getOnePuppyWithOutRedis(puppyId));
+	}
+
+	@GetMapping("/redis/{puppyId}")
+	@ResponseStatus(code = HttpStatus.OK)
+	public ResponseEntity<PuppyGetResponse> getOnePuppyWithRedis(
+			@PathVariable Long puppyId// , HttpSession session
 	) {
 		return ResponseEntity.ok(puppyReadService.getOnePuppy(puppyId));
 	}
@@ -59,22 +64,6 @@ public class PuppyController {
 			@Valid PuppyListGetRequest request
 	) {
 		return ResponseEntity.ok(puppyReadService.getPuppies(request));
-	}
-
-	@GetMapping("/filter")
-	@ResponseStatus(code = HttpStatus.OK)
-	public ResponseEntity<PuppyListGetResponse> getFilteredPuppies(
-			@Valid PuppyFilteredListGetRequest request
-	) {
-		return ResponseEntity.ok(puppyReadService.getFilteredPuppies(request));
-	}
-
-	@GetMapping("/sort")
-	@ResponseStatus(code = HttpStatus.OK)
-	public ResponseEntity<PuppyListGetResponse> getSortedPuppies(
-			@Valid PuppySortedListGetRequest request
-	) {
-		return ResponseEntity.ok(puppyReadService.getSortedPuppies(request));
 	}
 
 	@GetMapping("/enhanced")

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -55,7 +55,7 @@ public class PuppyReadService {
 	}
 
 	@Transactional(readOnly = true)
-	public PuppyListGetResponse getPuppiesWithSortingAndFiltering(EnhancedPuppyListGetRequest request) {
+	public PuppyListGetResponse getManyPuppiesWithCondition(EnhancedPuppyListGetRequest request) {
 		List<Puppy> puppies = puppyRepository.findPuppies(
 				request.cursorId(), request.pageSize(),
 				request.species(), request.sizes(),

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -46,11 +46,6 @@ public class PuppyReadService {
 	}
 
 	@Transactional(readOnly = true)
-	public PuppyGetResponse getOnePuppyWithOutRedis(Long puppyId) {
-		return toPuppyGetResponse(getEntity(puppyId));
-	}
-
-	@Transactional(readOnly = true)
 	public PuppyListGetResponse getPuppies(PuppyListGetRequest request) {
 
 		List<Puppy> puppies = puppyRepository.findPuppies(request.cursorId(), request.pageSize());

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -15,9 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
-import com.numble.popularpuppyvote.domain.dto.request.PuppyFilteredListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
-import com.numble.popularpuppyvote.domain.dto.request.PuppySortedListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyListGetResponse;
 import com.numble.popularpuppyvote.domain.model.Puppy;
@@ -48,6 +46,11 @@ public class PuppyReadService {
 	}
 
 	@Transactional(readOnly = true)
+	public PuppyGetResponse getOnePuppyWithOutRedis(Long puppyId) {
+		return toPuppyGetResponse(getEntity(puppyId));
+	}
+
+	@Transactional(readOnly = true)
 	public PuppyListGetResponse getPuppies(PuppyListGetRequest request) {
 
 		List<Puppy> puppies = puppyRepository.findPuppies(request.cursorId(), request.pageSize());
@@ -57,25 +60,7 @@ public class PuppyReadService {
 	}
 
 	@Transactional(readOnly = true)
-	public PuppyListGetResponse getFilteredPuppies(PuppyFilteredListGetRequest request) {
-		List<Puppy> puppies = puppyRepository.findPuppiesWithFiltering(request.cursorId(), request.pageSize(),
-				request.species(), request.sizes());
-		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
-
-		return toPuppiesGetResponse(puppies, lastId);
-	}
-
-	@Transactional(readOnly = true)
-	public PuppyListGetResponse getSortedPuppies(PuppySortedListGetRequest request) {
-		List<Puppy> puppies = puppyRepository.findPuppiesWithSorting(request.cursorId(), request.pageSize(),
-				request.criteria(), request.isAscending());
-		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
-
-		return toPuppiesGetResponse(puppies, lastId);
-	}
-
-	@Transactional(readOnly = true)
-	public PuppyListGetResponse enhancedGetPuppies(EnhancedPuppyListGetRequest request) {
+	public PuppyListGetResponse getPuppiesWithSortingAndFiltering(EnhancedPuppyListGetRequest request) {
 		List<Puppy> puppies = puppyRepository.findPuppies(
 				request.cursorId(), request.pageSize(),
 				request.species(), request.sizes(),


### PR DESCRIPTION
이전에 QueryDSL을 활용하면서 만들었던 정렬 및 필터링 확인용 메소드및 api 를 삭제한다
기존에는 레디스를 사용하던 단건 조회용 api 와 사용하지 않던 단건 조회용 api가 혼재했으나, 통일성 및 필요없는 api 정리를 위해 레디스를 사용하지 않는 api 는 삭제함
추가로 메소드 이름 수정 및 엔드포인트 수정함