### PR TITLE
[PPV-38] Redis의 Sorted Set 을 이용해서 강아지의 순위를 빠르게 제공받는다

### DIFF
--- a/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/api/PuppyController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyCreateRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
+import com.numble.popularpuppyvote.domain.dto.request.PuppyRankingGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyUpdateRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyCreateResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
@@ -26,7 +27,9 @@ import com.numble.popularpuppyvote.domain.service.PuppyReadService;
 import com.numble.popularpuppyvote.domain.service.PuppyService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/puppies")
 @RequiredArgsConstructor
@@ -66,6 +69,13 @@ public class PuppyController {
 	) {
 		return ResponseEntity.ok(puppyReadService.getManyPuppiesWithCondition(request));
 	}
+
+	@GetMapping("/ranking")
+	@ResponseStatus(code = HttpStatus.OK)
+	public ResponseEntity<PuppyListGetResponse> checkSortedSet(PuppyRankingGetRequest request) {
+		return ResponseEntity.ok(puppyReadService.getPuppiesByRanking(request));
+	}
+
 
 	@PatchMapping
 	@ResponseStatus(code = HttpStatus.OK)

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyRankingGetRequest.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/request/PuppyRankingGetRequest.java
@@ -1,0 +1,7 @@
+package com.numble.popularpuppyvote.domain.dto.request;
+
+public record PuppyRankingGetRequest(
+	Long startRanking,
+	Long endRanking
+) {
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/dto/response/PuppyRankingGetResponse.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/dto/response/PuppyRankingGetResponse.java
@@ -1,0 +1,9 @@
+package com.numble.popularpuppyvote.domain.dto.response;
+
+import java.util.List;
+
+public record PuppyRankingGetResponse(
+	List<PuppyGetResponse> puppies,
+	Long lastRanking
+) {
+}

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepository.java
@@ -17,4 +17,7 @@ public interface PuppyCustomRepository {
 	List<Puppy> findPuppiesWithSorting(Long compareId, int pageSize, SortingCriteria criteria, Boolean isAscending);
 
 	List<Puppy> findPuppies(Long cursorId, int pageSize, List<Species> species, List<Size> sizes, SortingCriteria criteria, Boolean isAscending);
+
+	List<Puppy> findPuppiesByIds(List<Long> ids);
+	Puppy findByIdCustom(Long id);
 }

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyCustomRepositoryImpl.java
@@ -83,6 +83,26 @@ public class PuppyCustomRepositoryImpl implements PuppyCustomRepository {
 				.fetch();
 	}
 
+	@Override
+	public List<Puppy> findPuppiesByIds(List<Long> ids) {
+		return jpaQueryFactory
+			.selectFrom(qPuppy)
+			.where(
+				qPuppy.id.in(ids)
+			)
+			.fetch();
+	}
+
+	@Override
+	public Puppy findByIdCustom(Long id) {
+		return jpaQueryFactory
+			.selectFrom(qPuppy)
+			.where(
+				qPuppy.id.eq(id)
+			)
+			.fetchFirst();
+	}
+
 	private BooleanExpression gtPuppyId(Long cursorId) {
 		return (cursorId != null) ? qPuppy.id.gt(cursorId) : null;
 	}

--- a/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyRepository.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/repository/PuppyRepository.java
@@ -21,6 +21,8 @@ public interface PuppyRepository extends JpaRepository<Puppy, Long>, PuppyCustom
 	@Query("SELECT DISTINCT p.id FROM Puppy as p GROUP BY p.id")
 	List<Long> getAllIdsDistinctGroupBy();
 
+	// List<Puppy> getPuppyByIdIn(List<Long> ids);
+
 	@Modifying
 	@Query("UPDATE Puppy as p SET p.likeCount = :likeCount WHERE p.id = :puppyId")
 	int updateLikeCountById(Long puppyId, Integer likeCount);

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/LikesService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/LikesService.java
@@ -30,16 +30,14 @@ public class LikesService {
 
 	private final LikesRepository likesRepository;
 	private final StringRedisTemplate redisTemplate;
-
-	private static final String RANKING_KEY = "likeRanking";
+	private static final String RANKING_KEY = "LIKE_RANKING";
 
 	@Transactional
 	public LikesRegisterResponse registerLikes(LikesRegisterRequest request) {
 		LikesRegisterResponse likesRegisterResponse = toLikesRegisterResponse(likesRepository.save(toLikes(request)));
 		ZSetOperations<String, String> zSet = redisTemplate.opsForZSet();
 
-		zSet.incrementScore(RANKING_KEY, likesRegisterResponse.id().toString(), 1);
-
+		zSet.incrementScore(RANKING_KEY, request.puppyId().toString(), 1);
 		return likesRegisterResponse;
 	}
 

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -39,7 +39,9 @@ public class PuppyReadService {
 		if (ops.get(key) != null) {
 			return ops.get(key);
 		} else {
+
 			PuppyGetResponse dto = toPuppyGetResponse(getEntity(puppyId));
+
 			ops.set(key, dto);
 			return dto;
 		}
@@ -64,6 +66,12 @@ public class PuppyReadService {
 
 		return toPuppiesGetResponse(puppies, lastId);
 	}
+
+
+	// @Transactional
+	// public List<PuppyGetResponse> getTopPuppies() {
+	//
+	// }
 
 	private Puppy getEntity(Long id) {
 		return puppyRepository.findById(id)

--- a/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
+++ b/src/main/java/com/numble/popularpuppyvote/domain/service/PuppyReadService.java
@@ -5,32 +5,43 @@ import static com.numble.popularpuppyvote.common.Message.PUPPY;
 import static com.numble.popularpuppyvote.common.mapper.PuppyMapper.toPuppiesGetResponse;
 import static com.numble.popularpuppyvote.common.mapper.PuppyMapper.toPuppyGetResponse;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityNotFoundException;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.numble.popularpuppyvote.common.mapper.PuppyMapper;
 import com.numble.popularpuppyvote.domain.dto.request.EnhancedPuppyListGetRequest;
 import com.numble.popularpuppyvote.domain.dto.request.PuppyListGetRequest;
+import com.numble.popularpuppyvote.domain.dto.request.PuppyRankingGetRequest;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyGetResponse;
 import com.numble.popularpuppyvote.domain.dto.response.PuppyListGetResponse;
 import com.numble.popularpuppyvote.domain.model.Puppy;
 import com.numble.popularpuppyvote.domain.repository.PuppyRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PuppyReadService {
 
 	private final PuppyRepository puppyRepository;
 	private final RedisTemplate<String, PuppyGetResponse> redisTemplate;
+	private final StringRedisTemplate stringRedisTemplate;
 
 	private static final String REDIS_PUPPY_KEY_PREFIX = "PUPPY";
+	private static final String RANKING_KEY = "LIKE_RANKING";
 
 	@Transactional(readOnly = true)
 	public PuppyGetResponse getOnePuppy(Long puppyId) {
@@ -59,22 +70,58 @@ public class PuppyReadService {
 	@Transactional(readOnly = true)
 	public PuppyListGetResponse getManyPuppiesWithCondition(EnhancedPuppyListGetRequest request) {
 		List<Puppy> puppies = puppyRepository.findPuppies(
-				request.cursorId(), request.pageSize(),
-				request.species(), request.sizes(),
-				request.criteria(), request.isAscending());
+			request.cursorId(), request.pageSize(),
+			request.species(), request.sizes(),
+			request.criteria(), request.isAscending());
 		long lastId = puppies.size() > 0 ? puppies.get(puppies.size() - 1).getId() : -1L;
 
 		return toPuppiesGetResponse(puppies, lastId);
 	}
 
+	@Transactional
+	public PuppyListGetResponse getPuppiesByRanking(PuppyRankingGetRequest request) {
+		ZSetOperations<String, String> zSet = stringRedisTemplate.opsForZSet();
+		List<String> rankingList = new ArrayList<>(
+			zSet.reverseRange(RANKING_KEY, request.startRanking(), request.endRanking()));
+		ValueOperations<String, PuppyGetResponse> ops = redisTemplate.opsForValue();
 
-	// @Transactional
-	// public List<PuppyGetResponse> getTopPuppies() {
-	//
-	// }
+		List<Long> unCachedIds = new ArrayList<>();
+		for (String id : rankingList) {
+			if (ops.get(id) == null) {
+				unCachedIds.add(Long.parseLong(id));
+			}
+		}
+
+		Map<Long, PuppyGetResponse> unCachedDtos = new HashMap<>();
+		if (unCachedIds.size() > 0) {
+			unCachedDtos = getPuppiesByIds(unCachedIds);
+			for (Long id: unCachedIds) {
+				ops.set(id.toString(), unCachedDtos.get(id));
+			}
+		}
+		List<PuppyGetResponse> puppyDtos = new ArrayList<>();
+		for (String id : rankingList) {
+			puppyDtos.add((ops.get(id) != null) ? ops.get(id) : unCachedDtos.get(Long.parseLong(id)));
+		}
+
+		return new PuppyListGetResponse(puppyDtos, request.endRanking());
+	}
+
+	private Map<Long, PuppyGetResponse> getPuppiesByIds(List<Long> ids) {
+
+		List<PuppyGetResponse> pList = puppyRepository.findPuppiesByIds(ids)
+			.stream()
+			.map(PuppyMapper::toPuppyGetResponse)
+			.toList();
+		Map<Long, PuppyGetResponse> pMap = new HashMap<>();
+		for (PuppyGetResponse dto : pList) {
+			pMap.put(dto.id(), dto);
+		}
+		return pMap;
+	}
 
 	private Puppy getEntity(Long id) {
 		return puppyRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(String.format(ENTITY_NOT_FOUND.name(), PUPPY.name())));
+			.orElseThrow(() -> new EntityNotFoundException(String.format(ENTITY_NOT_FOUND.name(), PUPPY.name())));
 	}
 }

--- a/src/test/java/com/numble/popularpuppyvote/domain/puppy/service/PuppyServiceTest.java
+++ b/src/test/java/com/numble/popularpuppyvote/domain/puppy/service/PuppyServiceTest.java
@@ -56,4 +56,5 @@ public class PuppyServiceTest {
 			assertThat(response.id()).isEqualTo(1L);
 		}
 	}
+
 }


### PR DESCRIPTION
강아지의 좋아요 순위를 Sorted Set을 이용해서 캐싱을 해 놓는다
매번 투표를 할 때마다 강아지의 좋아요 순위에 변동을 준다 - 39
그리고 강아지 전체 순위를 받아올 때, Sorted Set을 이용한다 - 40
 - 이 때, 해당 강아지의 상세 정보가 Redis 에 있는지 살펴보고 있으면 Redis에서 가져온다
 - 강아지의 상세 정보가 없으면, DB에서 가져온다
가져온 강아지 정보는 순위를 유지한 상태로 목록 형태로 전달한다.- 41